### PR TITLE
export: Fix nu::parser::unknown_flag

### DIFF
--- a/export.nu
+++ b/export.nu
@@ -1,67 +1,67 @@
 #update nushell sublime syntax
 export def "nushell-syntax-2-sublime" [] {
   let builtin = (
-      scope commands 
+      scope commands
       | where is_builtin == true and is_keyword == false
-      | get name 
-      | each {|com| 
-          $com 
-          | split row " " 
+      | get name
+      | each {|com|
+          $com
+          | split row " "
           | get 0
-        } 
+        }
       | flatten
       | uniq
       | str join " | "
   )
 
   let plugins = (
-      scope commands 
+      scope commands
       | where is_plugin == true
-      | get name 
-      | each {|com| 
-          $com 
+      | get name
+      | each {|com|
+          $com
           | split row " "
           | get 0
-        } 
+        }
       | flatten
       | uniq
       | str join " | "
   )
 
   let custom = (
-      scope commands 
+      scope commands
       | where is_custom == true
-      | get name 
-      | each {|com| 
-          $com 
-          | split row " " 
+      | get name
+      | each {|com|
+          $com
+          | split row " "
           | get 0
-        } 
+        }
       | flatten
       | uniq
       | str join " | "
-  )  
+  )
 
   let keywords = (
-      scope commands 
+      scope commands
       | where is_keyword == true
-      | get name 
-      | each {|com| 
-          $com 
-          | split row " " 
+      | get name
+      | each {|com|
+          $com
+          | split row " "
           | get 0
-        } 
+        }
       | flatten
       | uniq
       | str join " | "
-  ) 
+  )
 
   let aliases = (
-      scope aliases 
-      | get name 
+      scope aliases
+      | get name
       | uniq
       | str join " | "
-  )   
+  )
 
   let extra_builtin = " | else | catch"
   let builtin = "    (?x: " + $builtin + $extra_builtin + ")"
@@ -72,13 +72,13 @@ export def "nushell-syntax-2-sublime" [] {
   let operators = "    (?x: and | or | mod | in | not-in | not | xor | bit-or | bit-xor | bit-and | bit-shl | bit-shr | starts-with | ends-with)"
 
   let new_commands = [] ++ $builtin ++ $custom ++ $plugins ++ $keywords ++ $aliases ++ $operators
- 
+
   mut file = open ~/.config/sublime-text/Packages/User/nushell.sublime-syntax | lines
   let idx = $file | indexify | find '(?x:' | get index | drop
 
-  for -n i in $idx {
+  for i in $idx {
     $file = ($file | upsert $i.item ($new_commands | get $i.index))
   }
-  
+
   $file | save -f ~/.config/sublime-text/Packages/User/nushell.sublime-syntax
 }


### PR DESCRIPTION
```
❯ nu export.nu
Error: nu::parser::unknown_flag

  × The `for` command doesn't have flag `-n`.
    ╭─[~\scoop\persist\sublime-text\Data\Packages\nushell_sublime_syntax\export.nu:79:8]
 78 │
 79 │   for -n i in $idx {
    ·        ┬
    ·        ╰── unknown flag
 80 │     $file = ($file | upsert $i.item ($new_commands | get $i.index))
    ╰────
  help: Available flags: --help(-h). Use `--help` for more information.
```