### PR TITLE
fix: LSP settings naming error

### DIFF
--- a/Example-LSP.sublime-settings
+++ b/Example-LSP.sublime-settings
@@ -1,0 +1,13 @@
+{
+    "clients": {
+        "nushell": {
+            "command": [
+                "/home/kira/.cargo/bin/nu",
+                "--lsp",
+                "--no-config-file"
+            ],
+            "enabled": true,
+            "selector": "source.nu"
+        }
+    }
+}

--- a/LSP.sublime-settings
+++ b/LSP.sublime-settings
@@ -1,9 +1,0 @@
-// Settings in here override those in "LSP/LSP.sublime-settings"
-   { 
-       "clients": {
-           "nushell": {
-               "command": ["/home/kira/.cargo/bin/nu", "--lsp","--no-config-file"],
-               "enabled": true,
-               "selector": "source.nu"
-           },
-   }


### PR DESCRIPTION
1. Fixed the unmatched json braces.
1. Renamed file with an `Example-` prefix to avoid a plugin error on startup
___
Realistically if an actual `LSP-*.sublime-settings` file were to be included.
1. `command` wouldn't be a hardcoded path, and instead the user's `PATH` env should be checked in a `plugin.py` file, with potentially an option to hardcode.
1. Platform would be checked with the `os` module to resolve bin filename differences (Windows `.exe` suffix).

Imo, such a feature should be apart of it's own plugin, as typically LSP packages are separated in this way.